### PR TITLE
Add Snakemake workflow for kneaddata and DADA2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,5 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+results/
+*.snakemake

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # microbiome-pipeline
-To analyse microbiome data
+
+This repository contains a minimal Snakemake workflow that runs
+[kneaddata](https://github.com/biobakery/kneaddata) followed by
+[DADA2](https://benjjneb.github.io/dada2/) for microbiome data processing.
+
+## Quick start
+
+1. Create a conda environment with the required tools:
+
+   ```bash
+   conda env create -f environment.yaml
+   conda activate microbiome-pipeline
+   ```
+
+2. Place your raw FASTQ files in `data/raw/` and list the sample names in
+   `config.yaml`.
+
+3. Execute the workflow:
+
+   ```bash
+   snakemake --cores 4
+   ```
+
+Outputs from kneaddata are written to `results/kneaddata/` and DADA2
+results are saved as RDS files in `results/dada2/`.

--- a/Snakefile
+++ b/Snakefile
@@ -1,0 +1,25 @@
+configfile: "config.yaml"
+
+rule all:
+    input:
+        expand("results/dada2/{sample}.rds", sample=config["samples"])
+
+rule kneaddata:
+    input:
+        "data/raw/{sample}.fastq.gz"
+    output:
+        "results/kneaddata/{sample}_kneaddata.fastq.gz"
+    threads: 4
+    shell:
+        (
+            "kneaddata --input {input} --output results/kneaddata "
+            "--threads {threads} --log results/kneaddata/{wildcards.sample}.log"
+        )
+
+rule dada2:
+    input:
+        "results/kneaddata/{sample}_kneaddata.fastq.gz"
+    output:
+        "results/dada2/{sample}.rds"
+    shell:
+        "Rscript scripts/run_dada2.R {input} {output}"

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,3 @@
+samples:
+  - sample1
+  - sample2

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,10 @@
+name: microbiome-pipeline
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - snakemake
+  - kneaddata
+  - bioconductor-dada2
+  - r-base

--- a/scripts/run_dada2.R
+++ b/scripts/run_dada2.R
@@ -1,0 +1,15 @@
+#!/usr/bin/env Rscript
+args <- commandArgs(trailingOnly=TRUE)
+input_file <- args[1]
+output_file <- args[2]
+
+library(dada2)
+
+# Simple DADA2 workflow for a single sample
+filt <- tempfile(fileext=".fastq.gz")
+filterAndTrim(input_file, filt, truncLen=240, maxN=0, maxEE=2, truncQ=2, rm.phix=TRUE, multithread=FALSE)
+derep <- derepFastq(filt)
+dd <- dada(derep, err=NULL, multithread=FALSE)
+seqtab <- makeSequenceTable(dd)
+
+saveRDS(seqtab, output_file)


### PR DESCRIPTION
## Summary
- add Snakemake pipeline calling kneaddata and DADA2
- include example configuration and environment file
- provide simple R script for running DADA2
- update README with usage instructions
- restore `.gitignore` and ignore Snakemake files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68891a4fff6c832faa6830217e03c5d8